### PR TITLE
Fix font path for pdf generation

### DIFF
--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -24,8 +24,9 @@ def format_currency(value):
         return value
 
 
-# Register font
-pdfmetrics.registerFont(TTFont('DejaVu', os.path.join("fonts", "DejaVuSans.ttf")))
+# Register font relative to this module
+FONT_PATH = os.path.join(os.path.dirname(__file__), "..", "fonts", "DejaVuSans.ttf")
+pdfmetrics.registerFont(TTFont("DejaVu", FONT_PATH))
 
 # Get base styles
 styles = getSampleStyleSheet()


### PR DESCRIPTION
## Summary
- ensure `pdf_utils` loads the DejaVuSans font relative to the module path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442739c09483249c94a741e845264f