### PR TITLE
Add mid-period revision start support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Streamlit-based web app allows Public Sector Undertakings (PSUs) to calcula
 ## 🔧 Features
 
 - 📤 Upload original salary data (Excel format)
-- 📅 Select revision start date, fitment % and other allowance %
+- 📅 Choose the month and year from which the revision applies alongside fitment and allowance percentages
 - 📈 Generate revised salary for individual employees based on SAP number
 - 🪙 Apply PRC logic for increments, promotions, and grade-based pay scales
 - 🧾 Download a well-formatted PDF report showing:

--- a/pages/1_Individual_Impact.py
+++ b/pages/1_Individual_Impact.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import pandas as pd
 from utils.session_utils import get_original_data
-from utils.pay_revision_utils import calculate_individual_revision
+from utils.pay_revision_utils import calculate_individual_revision, month_order
 from utils.pdf_utils import generate_individual_pdf
 
 st.title("👤 Individual Salary Revision Impact")
@@ -33,10 +33,22 @@ if sap_no:
     fitment_pct = st.slider("Fitment %", 0, 30, 0)
     oa_pct = st.slider("Other Allowance %", 0, 35, 35)
 
+    months = list(month_order.keys())
+    year_options = sorted(emp_data["Year"].astype(int).unique())
+    start_year = st.selectbox("Revision Start Year", year_options, index=0)
+    start_month = st.selectbox("Revision Start Month", months, index=0)
+
+
     st.markdown("---")
     st.write("### Revised Salary Data")
 
-    revised_df, summary_df = calculate_individual_revision(emp_data, fitment_pct, oa_pct)
+    revised_df, summary_df = calculate_individual_revision(
+        emp_data,
+        fitment_pct,
+        oa_pct,
+        start_month,
+        int(start_year),
+    )
 
     st.dataframe(revised_df, use_container_width=True)
 
@@ -44,13 +56,15 @@ if sap_no:
     st.dataframe(summary_df, use_container_width=True)
 
     st.markdown("---")
+    revision_date = f"{start_month} {start_year}"
     if st.button("📥 Download PDF Report"):
         pdf_path = generate_individual_pdf(
             revised_df,  # Month-wise revised data
             sap_no,  # SAP number
             fitment_pct,  # Selected fitment rate
             oa_pct,  # Selected OA rate
-            summary_df  # Year-wise delta summary
+            summary_df,  # Year-wise delta summary
+            revision_date,
         )
 
         with open(pdf_path, "rb") as f:

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -44,7 +44,15 @@ normal_dejavu = ParagraphStyle(
 
 
 
-def generate_individual_pdf(df: pd.DataFrame, sap_no: str, fitment_pct: float, oa_pct: float, summary_df: pd.DataFrame, output_path: str = None) -> str:
+def generate_individual_pdf(
+    df: pd.DataFrame,
+    sap_no: str,
+    fitment_pct: float,
+    oa_pct: float,
+    summary_df: pd.DataFrame,
+    revision_date: str,
+    output_path: str | None = None,
+) -> str:
     if output_path is None:
         output_dir = "generated_pdfs"
         os.makedirs(output_dir, exist_ok=True)
@@ -90,6 +98,7 @@ def generate_individual_pdf(df: pd.DataFrame, sap_no: str, fitment_pct: float, o
     elements.append(Paragraph(f"<b>Status:</b> {status}", styles["Normal"]))
     elements.append(Paragraph(f"<b>Fitment %:</b> {fitment_pct}%", styles["Normal"]))
     elements.append(Paragraph(f"<b>OA %:</b> {oa_pct}%", styles["Normal"]))
+    elements.append(Paragraph(f"<b>Revision Start:</b> {revision_date}", styles["Normal"]))
     elements.append(Spacer(1, 0.2 * inch))
     elements.append(Paragraph(f"<b>Total Arrear With HRA:</b> {total_with_hra}", normal_dejavu))
     elements.append(Paragraph(f"<b>Total Arrear Without HRA:</b> {total_without_hra}", normal_dejavu))


### PR DESCRIPTION
## Summary
- allow selecting revision start month and year in Individual Impact page
- filter salary data from that date in `calculate_individual_revision`
- show chosen revision start date in generated PDF
- document feature in README

## Testing
- `python -m py_compile main.py pages/1_Individual_Impact.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6848f8e8e54c832485ba811c1de1fefd